### PR TITLE
Trib 132: adds shared header and menu button on smaller screet

### DIFF
--- a/src/app/_shared-components/header/header.component.html
+++ b/src/app/_shared-components/header/header.component.html
@@ -1,0 +1,3 @@
+<p>
+  header works!
+</p>

--- a/src/app/_shared-components/header/header.component.html
+++ b/src/app/_shared-components/header/header.component.html
@@ -1,3 +1,8 @@
-<p>
-  header works!
-</p>
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
+    </ion-buttons>
+      <ion-title>Page Title</ion-title>
+  </ion-toolbar>
+</ion-header>

--- a/src/app/_shared-components/header/header.component.html
+++ b/src/app/_shared-components/header/header.component.html
@@ -3,6 +3,6 @@
     <ion-buttons slot="start">
       <ion-menu-button></ion-menu-button>
     </ion-buttons>
-      <ion-title>Page Title</ion-title>
+      <ion-title>{{title}}</ion-title>
   </ion-toolbar>
 </ion-header>

--- a/src/app/_shared-components/header/header.component.spec.ts
+++ b/src/app/_shared-components/header/header.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { HeaderComponent } from './header.component';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HeaderComponent ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/_shared-components/header/header.component.ts
+++ b/src/app/_shared-components/header/header.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss'],
+})
+export class HeaderComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {}
+
+}

--- a/src/app/_shared-components/header/header.component.ts
+++ b/src/app/_shared-components/header/header.component.ts
@@ -1,14 +1,16 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
 })
+
+
 export class HeaderComponent implements OnInit {
 
   constructor() { }
-
+  @Input() public title: string = "";
   ngOnInit() {}
 
 }

--- a/src/app/_shared-components/shared-components/shared-components.module.ts
+++ b/src/app/_shared-components/shared-components/shared-components.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule
+  ]
+})
+export class SharedComponentsModule { }

--- a/src/app/_shared-components/shared-components/shared-components.module.ts
+++ b/src/app/_shared-components/shared-components/shared-components.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
+import { HeaderComponent } from '../header/header.component';
 
 
 @NgModule({
-  declarations: [],
+  declarations: [HeaderComponent],
   imports: [
     CommonModule
-  ]
+  ],
+  exports: [HeaderComponent]
 })
 export class SharedComponentsModule { }

--- a/src/app/_shared-components/shared-components/shared-components.module.ts
+++ b/src/app/_shared-components/shared-components/shared-components.module.ts
@@ -1,12 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../header/header.component';
+import { IonicModule } from '@ionic/angular';
 
 
 @NgModule({
   declarations: [HeaderComponent],
   imports: [
-    CommonModule
+    CommonModule,
+    IonicModule
   ],
   exports: [HeaderComponent]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { HttpConfigInterceptor } from './_services/_http/interceptor.service';
 
 import { Constants } from './_constants/constants';
+import { SharedComponentsModule } from './_shared-components/shared-components/shared-components.module'
 
 import { HammerGestureConfig, HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
 import { WebView } from '@ionic-native/ionic-webview/ngx';
@@ -33,7 +34,8 @@ export class CustomHammerConfig extends HammerGestureConfig {
       SavvatoJavascriptServicesModule,
       HttpClientModule,
       AppRoutingModule,
-      HammerModule
+      HammerModule,
+      SharedComponentsModule
   ],
   providers: [
     {

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -7,13 +7,15 @@ import { IonicModule } from '@ionic/angular';
 import { HomePageRoutingModule } from './home-routing.module';
 
 import { HomePage } from './home.page';
+import { SharedComponentsModule } from '../_shared-components/shared-components/shared-components.module';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
-    HomePageRoutingModule
+    HomePageRoutingModule,
+    SharedComponentsModule
   ],
   declarations: [HomePage]
 })

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,5 +1,5 @@
 
-<app-header></app-header>
+<app-header [title]="currentTitle"></app-header>
 
 <ion-content>
 

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -1,9 +1,5 @@
 
-<ion-header>
-  <ion-toolbar>
-      <ion-title>Home</ion-title>
-  </ion-toolbar>
-</ion-header>
+<app-header></app-header>
 
 <ion-content>
 

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -18,6 +18,7 @@ export class HomePage implements OnInit {
   @ViewChildren(IonCard, {read: ElementRef}) cards: QueryList<ElementRef>
 
   modelList: any = [];
+  currentTitle: string = "Home";
 
   constructor(private _authService:AuthService,
               private _alertService: AlertService,


### PR DESCRIPTION
NOTE: this branch is directly off the frontend develop branch

- Creates shared-components directory and module
- adds header to shared directory
- add menu button to header for smaller screens
- integrates shared header on home page only, so far

Testing: compiles and runs

Questions: 
- Any changes or suggestions?
- Do you want me to include the shared header on other existing pages (this includes replacing the current headers with a call to the app header and adding a title property to page ts file). 

current pages include:
- home
- attributes
- connect
- notifications
- permissions
- profile