### PR TITLE
TRIB-126: integrates input fields and btns to review phrase

### DIFF
--- a/cypress/e2e/review-attributes.page.cy.ts
+++ b/cypress/e2e/review-attributes.page.cy.ts
@@ -43,4 +43,30 @@ describe('check for inputs and buttons on review attributes page', () => {
 
     })
 
+    // display alert after reject button clicked (expect: mock data option "doesn't make sense")
+    it('should display an alert after reject button clicked', () => {
+
+        // click get next phrase button
+        cy.get('[data-test="launchGetNextPhraseBtn"]').should('have.length', 1)
+        cy.get('[data-test="launchGetNextPhraseBtn"]').click()
+        
+        // click reject button
+        cy.get('[data-test="launchRejectBtn"]').should('have.length', 1)
+        cy.get('[data-test="launchRejectBtn"]').click()
+
+        // Assert that the alert is displayed
+        cy.get('ion-alert').should('be.visible');
+
+        // Interact with the elements inside the alert
+        cy.get('ion-alert')
+            .within(() => {
+                cy.get('button').contains("doesn\'t make sense").click(); 
+                cy.get('button').contains('OK').click(); // dismiss alert to continue any following tests
+            });
+
+        // Assert that the alert is no longer visible (it has been dismissed)
+        cy.get('ion-alert').should('not.exist');
+
+    })
+
 })

--- a/cypress/e2e/review-attributes.page.cy.ts
+++ b/cypress/e2e/review-attributes.page.cy.ts
@@ -22,4 +22,25 @@ describe('check for inputs and buttons on review attributes page', () => {
 
     })
 
+    // display alert after approve button clicked
+    it('should display an alert after approve button clicked', () => {
+        
+        // click approve button
+        cy.get('[data-test="launchApproveBtn"]').should('have.length', 1)
+        cy.get('[data-test="launchApproveBtn"]').click()
+
+        // Assert that the alert is displayed
+        cy.get('ion-alert').should('be.visible');
+
+        // Interact with the elements inside the alert
+        cy.get('ion-alert')
+            .within(() => {
+                cy.get('button').contains('OK').click(); // dismiss alert to continue any following tests
+            });
+
+        // Assert that the alert is no longer visible (it has been dismissed)
+        cy.get('ion-alert').should('not.exist');
+
+    })
+
 })

--- a/cypress/e2e/review-attributes.page.cy.ts
+++ b/cypress/e2e/review-attributes.page.cy.ts
@@ -1,0 +1,12 @@
+describe('check for inputs and buttons on review attributes page', () => {
+
+    // get to review attributes page
+    it('navigate to review attributes page', () => {
+        cy.visit('http://localhost:8100/login')
+        cy.get('[data-test="sign-in-btn"]').click()
+
+        cy.get('[data-test="launchToBeReviewedPageButton"]').should('have.length', 1)
+        cy.get('[data-test="launchToBeReviewedPageButton"]').click()
+    })
+
+})

--- a/cypress/e2e/review-attributes.page.cy.ts
+++ b/cypress/e2e/review-attributes.page.cy.ts
@@ -14,4 +14,12 @@ describe('check for inputs and buttons on review attributes page', () => {
         cy.get('input[placeholder*="Click get next phrase to review"]')
     })
 
+    // display mock phrase in input field when get next phrase button clicked (expect: competitively writes nullvalue code)
+    it('check to see if the get next review button displays mock data in input field', () => {
+        cy.get('[data-test="launchGetNextPhraseBtn"]').should('have.length', 1)
+        cy.get('[data-test="launchGetNextPhraseBtn"]').click()
+        cy.get('[data-test="inputPhraseToBeReviewed"]').should('have.value', "competitively writes nullvalue code")
+
+    })
+
 })

--- a/cypress/e2e/review-attributes.page.cy.ts
+++ b/cypress/e2e/review-attributes.page.cy.ts
@@ -9,4 +9,9 @@ describe('check for inputs and buttons on review attributes page', () => {
         cy.get('[data-test="launchToBeReviewedPageButton"]').click()
     })
 
+    // display placeholder text in input field (expect: Click get next phrase to review)
+    it('should display placeholder text in input field', () => {
+        cy.get('input[placeholder*="Click get next phrase to review"]')
+    })
+
 })

--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -6,7 +6,7 @@
   This is the home page!
 
   <ion-button (click)="onGoToAttritubesBtnClick()" data-test="launchAttributesPageButton" fill="clear">Edit Your Attributes</ion-button>
-  <ion-button (click)="onGoToReviewAttributesBtnClick()" fill="clear">Review Attributes</ion-button>
+  <ion-button (click)="onGoToReviewAttributesBtnClick()" data-test="launchToBeReviewedPageButton"fill="clear">Review Attributes</ion-button>
   <ion-button (click)="onGoToNotificationBtnClick()" fill="clear">Notifications</ion-button>
   <ion-button (click)="onGoToPermissionsBtnClick()" data-test="launchPermissionsPageButton" fill="clear">Edit Your Permissions</ion-button>
 </ion-content>

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -6,7 +6,7 @@
   </ion-item>
   <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="getNextPhraseButtonDisabled" data-test="launchGetNextPhraseBtn">Get Next Phrase</ion-button>
   <ion-buttons *ngIf="approveAndRejectButtonDisplayed">
-    <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" >Approve</ion-button>
+    <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" data-test="launchApproveBtn">Approve</ion-button>
     <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" >Reject</ion-button>
   </ion-buttons>
 </ion-content>

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -10,5 +10,13 @@
   </ion-item>
   <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="getNextPhraseButtonDisabled">Get Next Phrase</ion-button>
   <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" [disabled]="approveButtonDisabled">Approve</ion-button>
-  <ion-button color="tertiary" (click)="onRejectPhraseBtnClick()" [disabled]="rejectButtonDisabled">Reject</ion-button>
+  <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" [disabled]="rejectButtonDisabled">Reject</ion-button>
+    <ion-alert
+    trigger="reject"
+    header="Select your favorite color"
+    [buttons]="alertButtons"
+    [inputs]="alertInputs"
+  ></ion-alert>
+
 </ion-content>
+

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -11,12 +11,12 @@
   <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="getNextPhraseButtonDisabled">Get Next Phrase</ion-button>
   <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" [disabled]="approveButtonDisabled">Approve</ion-button>
   <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" [disabled]="rejectButtonDisabled">Reject</ion-button>
-    <ion-alert
-    trigger="reject"
-    header="Select your favorite color"
-    [buttons]="alertButtons"
-    [inputs]="alertInputs"
-  ></ion-alert>
-
 </ion-content>
+
+<ion-alert
+trigger="reject"
+header="Select your favorite color"
+[buttons]="alertButtons"
+[inputs]="alertInputs"
+></ion-alert>
 

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -9,6 +9,8 @@
     <ion-input label="phrase" [value]="phraseToBeReviewed" placeholder="Click get next phrase to review" [readonly]="true"></ion-input>
   </ion-item>
   <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="getNextPhraseButtonDisabled">Get Next Phrase</ion-button>
-  <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" [disabled]="approveButtonDisabled">Approve</ion-button>
-  <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" [disabled]="rejectButtonDisabled">Reject</ion-button>
+  <ion-buttons *ngIf="approveAndRejectButtonDisplayed">
+    <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" >Approve</ion-button>
+    <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" >Reject</ion-button>
+  </ion-buttons>
 </ion-content>

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -7,6 +7,6 @@
   <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="getNextPhraseButtonDisabled" data-test="launchGetNextPhraseBtn">Get Next Phrase</ion-button>
   <ion-buttons *ngIf="approveAndRejectButtonDisplayed">
     <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" data-test="launchApproveBtn">Approve</ion-button>
-    <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" >Reject</ion-button>
+    <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" data-test="launchRejectBtn">Reject</ion-button>
   </ion-buttons>
 </ion-content>

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -6,7 +6,7 @@
 
 <ion-content>
   <ion-item>
-    <ion-input label="phrase" value="testing" [readonly]="true"></ion-input>
+    <ion-input label="phrase" [value]="getNextPhraseToBeReviewed()" [readonly]="true"></ion-input>
   </ion-item>
   <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="true">Get Next Phrase</ion-button>
   <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" [disabled]="false">Approve</ion-button> <ion-button

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -1,8 +1,4 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Review Attributes</ion-title>
-  </ion-toolbar>
-</ion-header>
+<app-header [currentPageTitle]="headerPageTitle"></app-header>
 
 <ion-content>
   <ion-item>

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -12,11 +12,3 @@
   <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" [disabled]="approveButtonDisabled">Approve</ion-button>
   <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" [disabled]="rejectButtonDisabled">Reject</ion-button>
 </ion-content>
-
-<ion-alert
-trigger="reject"
-header="Select your favorite color"
-[buttons]="alertButtons"
-[inputs]="alertInputs"
-></ion-alert>
-

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -6,9 +6,9 @@
 
 <ion-content>
   <ion-item>
-    <ion-input label="phrase" [value]="getNextPhraseToBeReviewed()" [readonly]="true"></ion-input>
+    <ion-input label="phrase" [value]="phraseToBeReviewed" placeholder="Click get next phrase to review" [readonly]="true"></ion-input>
   </ion-item>
-  <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="true">Get Next Phrase</ion-button>
-  <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" [disabled]="false">Approve</ion-button> <ion-button
-    color="tertiary" (click)="onRejectPhraseBtnClick()" [disabled]="false">Reject</ion-button>
+  <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="getNextPhraseButtonDisabled">Get Next Phrase</ion-button>
+  <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" [disabled]="approveButtonDisabled">Approve</ion-button>
+  <ion-button color="tertiary" (click)="onRejectPhraseBtnClick()" [disabled]="rejectButtonDisabled">Reject</ion-button>
 </ion-content>

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -5,5 +5,10 @@
 </ion-header>
 
 <ion-content>
-
+  <ion-item>
+    <ion-input label="phrase" value="testing" [readonly]="true"></ion-input>
+  </ion-item>
+  <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="true">Get Next Phrase</ion-button>
+  <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" [disabled]="false">Approve</ion-button> <ion-button
+    color="tertiary" (click)="onRejectPhraseBtnClick()" [disabled]="false">Reject</ion-button>
 </ion-content>

--- a/src/app/pages/review-attributes/review-attributes.page.html
+++ b/src/app/pages/review-attributes/review-attributes.page.html
@@ -2,9 +2,9 @@
 
 <ion-content>
   <ion-item>
-    <ion-input label="phrase" [value]="phraseToBeReviewed" placeholder="Click get next phrase to review" [readonly]="true"></ion-input>
+    <ion-input label="phrase" [value]="phraseToBeReviewed" placeholder="Click get next phrase to review" [readonly]="true" data-test="inputPhraseToBeReviewed"></ion-input>
   </ion-item>
-  <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="getNextPhraseButtonDisabled">Get Next Phrase</ion-button>
+  <ion-button color="tertiary" (click)="onGetNextPhraseBtnClick()" [disabled]="getNextPhraseButtonDisabled" data-test="launchGetNextPhraseBtn">Get Next Phrase</ion-button>
   <ion-buttons *ngIf="approveAndRejectButtonDisplayed">
     <ion-button color="tertiary" (click)="onApprovePhraseBtnClick()" >Approve</ion-button>
     <ion-button id="reject" color="tertiary" (click)="onRejectPhraseBtnClick()" >Reject</ion-button>

--- a/src/app/pages/review-attributes/review-attributes.page.module.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.module.ts
@@ -7,13 +7,15 @@ import { IonicModule } from '@ionic/angular';
 import { ReviewAttributesPageRoutingModule } from './review-attributes-routing.module';
 
 import { ReviewAttributesPage } from './review-attributes.page';
+import { SharedComponentsModule } from '../../_shared-components/shared-components/shared-components.module';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
-    ReviewAttributesPageRoutingModule
+    ReviewAttributesPageRoutingModule, 
+    SharedComponentsModule
   ],
   declarations: [ReviewAttributesPage]
 })

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
 import { AlertService } from '../../_services/alert/alert.service';
-import { LoadingService } from "../../_services/loading-spinner/loading.service";
 
 @Component({
   selector: 'app-review-attributes',
@@ -15,9 +14,7 @@ export class ReviewAttributesPage implements OnInit {
   approveButtonDisabled: boolean = true;
   rejectButtonDisabled: boolean = true;
 
-  constructor(private _alertService: AlertService,
-    private _loadingService: LoadingService
-  ) { }
+  constructor(private _alertService: AlertService) { }
 
   ngOnInit() {
   }
@@ -46,19 +43,14 @@ export class ReviewAttributesPage implements OnInit {
   onApprovePhraseBtnClick() {
     const self = this;
     let msg = 'Message approved!';
-
-    self._loadingService.show({ message: msg }).then(() => {
-      self._loadingService.dismiss().then(() => {
-        self._alertService.show({
-          header: 'Alright!',
-          message: msg,
-          buttons: [{
-            text: 'OK', role: 'cancel',
-            handler: () => {
-            }
-          }]
-        })
-      })
+    self._alertService.show({
+    header: 'Alright!',
+    message: msg,
+    buttons: [{
+      text: 'OK', role: 'cancel',
+      handler: () => {
+      }
+      }]
     })
     this.phraseToBeReviewed = "";
     this.getNextPhraseButtonDisabled = false;

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -20,32 +20,42 @@ export class ReviewAttributesPage implements OnInit {
   }
 
   onRejectPhraseBtnClick() {
-    let alertButtons = ['OK'];
-    let alertInputs = [
-    {
-      label: 'Red',
-      type: 'radio',
-      value: 'red',
-    },
-    {
-      label: 'Blue',
-      type: 'radio',
-      value: 'blue',
-    },
-    {
-      label: 'Green',
-      type: 'radio',
-      value: 'green',
-    },
-  ];
+    //mock data
+    const reasons = [
+      {"id": 1, "reason": "approved"},
+      {"id": 2, "reason": "doesn't make sense"},
+      {"id": 3, "reason": "vulgar"}];
+
+    const self = this;
+
+    self._alertService.show({
+      header: 'Message rejected',
+      subheader: 'Choose a reason why:',
+      inputs: reasons.map((rsn) => {
+              return {
+                  type: 'radio',
+                  label: rsn.reason,
+                  value: rsn.reason
+              }
+          }, self),
+      buttons: [{
+        text: 'OK', role: 'cancel',
+        handler: () => {
+        }
+        }]
+    })
+
+    this.phraseToBeReviewed = "";
+    this.getNextPhraseButtonDisabled = false;
+    this.approveButtonDisabled = true;
+    this.rejectButtonDisabled = true;
   }
 
   onApprovePhraseBtnClick() {
     const self = this;
     let msg = 'Message approved!';
     self._alertService.show({
-    header: 'Alright!',
-    message: msg,
+    header: msg,
     buttons: [{
       text: 'OK', role: 'cancel',
       handler: () => {

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -23,7 +23,24 @@ export class ReviewAttributesPage implements OnInit {
   }
 
   onRejectPhraseBtnClick() {
-    throw new Error('Method not implemented.');
+    let alertButtons = ['OK'];
+    let alertInputs = [
+    {
+      label: 'Red',
+      type: 'radio',
+      value: 'red',
+    },
+    {
+      label: 'Blue',
+      type: 'radio',
+      value: 'blue',
+    },
+    {
+      label: 'Green',
+      type: 'radio',
+      value: 'green',
+    },
+  ];
   }
 
   onApprovePhraseBtnClick() {

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -62,7 +62,7 @@ export class ReviewAttributesPage implements OnInit {
       }
       }]
     })
-    
+
     this.phraseToBeReviewed = "";
     this.getNextPhraseButtonDisabled = false;
     this.approveButtonDisabled = true;
@@ -74,7 +74,9 @@ export class ReviewAttributesPage implements OnInit {
   }
 
   getNextPhraseToBeReviewed() {
+    //mock data
     const phraseTBR = {"adverb": "competitively", "verb": "writes", "preposition": "nullvalue", "noun": "code" };
+    
     const phraseTBRAsString = this.getAttrString(phraseTBR);
     this.phraseToBeReviewed = phraseTBRAsString;
     this.getNextPhraseButtonDisabled = true;

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -12,4 +12,22 @@ export class ReviewAttributesPage implements OnInit {
   ngOnInit() {
   }
 
+  onRejectPhraseBtnClick() {
+    throw new Error('Method not implemented.');
+  }
+  onApprovePhraseBtnClick() {
+    throw new Error('Method not implemented.');
+  }
+  onGetNextPhraseBtnClick() {
+    this.getNextPhraseToBeReviewed();
+  }
+  getNextPhraseToBeReviewed() {
+    return [{
+      "phrase": {
+        "adverb": "competitively", "verb": "writes", "preposition": "nullvalue", "noun": "code"
+      }
+    }
+    ];
+  }
+
 }

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -36,7 +36,10 @@ export class ReviewAttributesPage implements OnInit {
               return {
                   type: 'radio',
                   label: rsn.reason,
-                  value: rsn.reason
+                  value: rsn.reason,
+                  handler: (data) => {
+                    console.log('User choice: ', data.value);
+                  }
               }
           }, self),
       buttons: [{

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -7,6 +7,11 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ReviewAttributesPage implements OnInit {
 
+  phraseToBeReviewed:String = "";
+  getNextPhraseButtonDisabled:boolean = false;
+  approveButtonDisabled:boolean = true;
+  rejectButtonDisabled:boolean = true;
+
   constructor() { }
 
   ngOnInit() {
@@ -27,7 +32,10 @@ export class ReviewAttributesPage implements OnInit {
   getNextPhraseToBeReviewed() {
     const phraseTBR = {"adverb": "competitively", "verb": "writes", "preposition": "nullvalue", "noun": "code"};
     const phraseTBRAsString = this.getAttrString(phraseTBR);  
-    return phraseTBRAsString;
+    this.phraseToBeReviewed = phraseTBRAsString;
+    this.getNextPhraseButtonDisabled = true;
+    this.approveButtonDisabled = false;
+    this.rejectButtonDisabled = false;
   }
 
   getAttrString(tbr) {

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -15,19 +15,39 @@ export class ReviewAttributesPage implements OnInit {
   onRejectPhraseBtnClick() {
     throw new Error('Method not implemented.');
   }
+
   onApprovePhraseBtnClick() {
     throw new Error('Method not implemented.');
   }
+
   onGetNextPhraseBtnClick() {
     this.getNextPhraseToBeReviewed();
   }
+
   getNextPhraseToBeReviewed() {
-    return [{
-      "phrase": {
-        "adverb": "competitively", "verb": "writes", "preposition": "nullvalue", "noun": "code"
-      }
-    }
-    ];
+    const phraseTBR = {"adverb": "competitively", "verb": "writes", "preposition": "nullvalue", "noun": "code"};
+    const phraseTBRAsString = this.getAttrString(phraseTBR);  
+    return phraseTBRAsString;
+  }
+
+  getAttrString(tbr) {
+    let rtn = "";
+
+    if (tbr.adverb)
+      rtn += tbr.adverb + " ";
+
+      rtn += tbr.verb + " ";
+
+    if (tbr.preposition)
+      rtn += tbr.preposition + " ";
+
+    rtn += tbr.noun;
+
+    return rtn;
+  }
+
+  getListOfReviewDecisionReasons() {
+    return
   }
 
 }

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 
+import { AlertService } from '../../_services/alert/alert.service';
+import { LoadingService } from "../../_services/loading-spinner/loading.service";
+
 @Component({
   selector: 'app-review-attributes',
   templateUrl: './review-attributes.page.html',
@@ -7,12 +10,14 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ReviewAttributesPage implements OnInit {
 
-  phraseToBeReviewed:String = "";
-  getNextPhraseButtonDisabled:boolean = false;
-  approveButtonDisabled:boolean = true;
-  rejectButtonDisabled:boolean = true;
+  phraseToBeReviewed: String = "";
+  getNextPhraseButtonDisabled: boolean = false;
+  approveButtonDisabled: boolean = true;
+  rejectButtonDisabled: boolean = true;
 
-  constructor() { }
+  constructor(private _alertService: AlertService,
+    private _loadingService: LoadingService
+  ) { }
 
   ngOnInit() {
   }
@@ -22,7 +27,26 @@ export class ReviewAttributesPage implements OnInit {
   }
 
   onApprovePhraseBtnClick() {
-    throw new Error('Method not implemented.');
+    const self = this;
+    let msg = 'Message approved!';
+
+    self._loadingService.show({ message: msg }).then(() => {
+      self._loadingService.dismiss().then(() => {
+        self._alertService.show({
+          header: 'Alright!',
+          message: msg,
+          buttons: [{
+            text: 'OK', role: 'cancel',
+            handler: () => {
+            }
+          }]
+        })
+      })
+    })
+    this.phraseToBeReviewed = "";
+    this.getNextPhraseButtonDisabled = false;
+    this.approveButtonDisabled = true;
+    this.rejectButtonDisabled = true;
   }
 
   onGetNextPhraseBtnClick() {
@@ -30,8 +54,8 @@ export class ReviewAttributesPage implements OnInit {
   }
 
   getNextPhraseToBeReviewed() {
-    const phraseTBR = {"adverb": "competitively", "verb": "writes", "preposition": "nullvalue", "noun": "code"};
-    const phraseTBRAsString = this.getAttrString(phraseTBR);  
+    const phraseTBR = {"adverb": "competitively", "verb": "writes", "preposition": "nullvalue", "noun": "code" };
+    const phraseTBRAsString = this.getAttrString(phraseTBR);
     this.phraseToBeReviewed = phraseTBRAsString;
     this.getNextPhraseButtonDisabled = true;
     this.approveButtonDisabled = false;
@@ -44,7 +68,7 @@ export class ReviewAttributesPage implements OnInit {
     if (tbr.adverb)
       rtn += tbr.adverb + " ";
 
-      rtn += tbr.verb + " ";
+    rtn += tbr.verb + " ";
 
     if (tbr.preposition)
       rtn += tbr.preposition + " ";

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -11,8 +11,7 @@ export class ReviewAttributesPage implements OnInit {
 
   phraseToBeReviewed: String = "";
   getNextPhraseButtonDisabled: boolean = false;
-  approveButtonDisabled: boolean = true;
-  rejectButtonDisabled: boolean = true;
+  approveAndRejectButtonDisplayed: boolean = false;
 
   constructor(private _alertService: AlertService) { }
 
@@ -47,8 +46,7 @@ export class ReviewAttributesPage implements OnInit {
 
     this.phraseToBeReviewed = "";
     this.getNextPhraseButtonDisabled = false;
-    this.approveButtonDisabled = true;
-    this.rejectButtonDisabled = true;
+    this.approveAndRejectButtonDisplayed = false;
   }
 
   onApprovePhraseBtnClick() {
@@ -65,8 +63,7 @@ export class ReviewAttributesPage implements OnInit {
 
     this.phraseToBeReviewed = "";
     this.getNextPhraseButtonDisabled = false;
-    this.approveButtonDisabled = true;
-    this.rejectButtonDisabled = true;
+    this.approveAndRejectButtonDisplayed = false;
   }
 
   onGetNextPhraseBtnClick() {
@@ -76,12 +73,11 @@ export class ReviewAttributesPage implements OnInit {
   getNextPhraseToBeReviewed() {
     //mock data
     const phraseTBR = {"adverb": "competitively", "verb": "writes", "preposition": "nullvalue", "noun": "code" };
-    
+
     const phraseTBRAsString = this.getAttrString(phraseTBR);
     this.phraseToBeReviewed = phraseTBRAsString;
     this.getNextPhraseButtonDisabled = true;
-    this.approveButtonDisabled = false;
-    this.rejectButtonDisabled = false;
+    this.approveAndRejectButtonDisplayed = true;
   }
 
   getAttrString(tbr) {

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -53,15 +53,16 @@ export class ReviewAttributesPage implements OnInit {
 
   onApprovePhraseBtnClick() {
     const self = this;
-    let msg = 'Message approved!';
+
     self._alertService.show({
-    header: msg,
+    header: 'Message approved!',
     buttons: [{
       text: 'OK', role: 'cancel',
       handler: () => {
       }
       }]
     })
+    
     this.phraseToBeReviewed = "";
     this.getNextPhraseButtonDisabled = false;
     this.approveButtonDisabled = true;

--- a/src/app/pages/review-attributes/review-attributes.page.ts
+++ b/src/app/pages/review-attributes/review-attributes.page.ts
@@ -9,6 +9,8 @@ import { AlertService } from '../../_services/alert/alert.service';
 })
 export class ReviewAttributesPage implements OnInit {
 
+  headerPageTitle: string = 'Review Attributes';
+
   phraseToBeReviewed: String = "";
   getNextPhraseButtonDisabled: boolean = false;
   approveAndRejectButtonDisplayed: boolean = false;


### PR DESCRIPTION
Integrated with mock data located in review-phrase.page.ts

- Adds a read-only input field to display phrase string to be reviewed
- Adds a Get Next Phrase button to display the next available phrase
- Adds Approve and Reject buttons 
- Displays alert for Approve: confirmation
- Displays alert for Reject: choose reason
- Adds Console log to reject button

Testing:
- Compiles and runs
- Functions in browser as expected
Cypress tests pass
- navigate to review attributes
-  should display placeholder text in input 
- check to see if the get next review button displays mock data in input 
- should display an alert after approve button  
- should display an alert after reject button clicked