### PR TITLE
Removed trailing slashes in API URLs because spring doesn't like them…

### DIFF
--- a/src/app/pages/attributes-page/_services/attributes.api.service.ts
+++ b/src/app/pages/attributes-page/_services/attributes.api.service.ts
@@ -27,7 +27,7 @@ export class AttributesApiService {
 
 
     save(model) {
-        const url = environment.apiUrl + '/api/attributes/';
+        const url = environment.apiUrl + '/api/attributes';
         let data = {
             'adverb': model['inputAdverbText'],
             'verb': model['inputVerbText'],

--- a/src/app/pages/notifications-page/_service/notifications.api.service.ts
+++ b/src/app/pages/notifications-page/_service/notifications.api.service.ts
@@ -24,7 +24,7 @@ export class NotificationApiService {
         }
     }
     async readNotification(notificationId: number) {
-        const url = environment.apiUrl + '/api/notifications/';
+        const url = environment.apiUrl + '/api/notifications';
         console.log("apiservice started")
         try{
             let data = {"id" : notificationId}

--- a/src/app/pages/review-attributes/_services/review-attributes.api.service.ts
+++ b/src/app/pages/review-attributes/_services/review-attributes.api.service.ts
@@ -9,7 +9,7 @@ export class ReviewAttributesApiService {
   constructor(private _apiService: JWTApiService) {}
 
   getNextReviewEligiblePhrase() {
-    const url = environment.apiUrl + "/api/review/";
+    const url = environment.apiUrl + "/api/review";
 
     return new Promise((resolve, reject) => {
       this._apiService.get(url).subscribe((_data) => {


### PR DESCRIPTION
Removed trailing slashes in API URLs because spring doesn't like them, it considers it an entirely different url.